### PR TITLE
[WIP] id generation middleware 

### DIFF
--- a/dev/App.module.css
+++ b/dev/App.module.css
@@ -36,6 +36,7 @@
   font-size: 10pt;
   line-height: 14pt;
   text-align: left;
+  white-space: nowrap;
 }
 
 .dirEnt:focus {

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -63,8 +63,8 @@ const App: Component = () => {
             const [editable, setEditable] = createSignal(false)
 
             onMount(() => {
-              if (dirEnt.focused && dirEnt.type === 'file') {
-                setSelectedFile(dirEnt.path)
+              if (dirEnt().focused && dirEnt().type === 'file') {
+                setSelectedFile(dirEnt().path)
               }
             })
 
@@ -72,28 +72,29 @@ const App: Component = () => {
               <FileTree.DirEnt
                 class={styles.dirEnt}
                 style={{
-                  background: dirEnt.selected ? '#484f6c' : undefined,
+                  background: dirEnt().selected ? '#484f6c' : undefined,
                 }}
                 onDblClick={() => setEditable(true)}
                 onMouseDown={() => {
-                  if (dirEnt.type === 'file') {
-                    setSelectedFile(dirEnt.path)
+                  if (dirEnt().type === 'file') {
+                    setSelectedFile(dirEnt().path)
                   }
                 }}
                 onKeyDown={e => {
+                  const _dirEnt = dirEnt()
                   switch (e.code) {
                     case 'Enter':
                       setEditable(editable => !editable)
                       break
                     case 'Space':
-                      if (dirEnt.type === 'dir') {
-                        if (dirEnt.expanded) {
-                          dirEnt.collapse()
+                      if (_dirEnt.type === 'dir') {
+                        if (_dirEnt.expanded) {
+                          _dirEnt.collapse()
                         } else {
-                          dirEnt.expand()
+                          _dirEnt.expand()
                         }
                       } else {
-                        setSelectedFile(dirEnt.path)
+                        setSelectedFile(_dirEnt.path)
                       }
                       break
                   }
@@ -109,7 +110,7 @@ const App: Component = () => {
                 />
                 <FileTree.Name
                   editable={editable()}
-                  style={{ 'margin-left': dirEnt.type === 'file' ? '7.5px' : undefined }}
+                  style={{ 'margin-left': dirEnt().type === 'file' ? '7.5px' : undefined }}
                   onBlur={() => setEditable(false)}
                 />
               </FileTree.DirEnt>

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@solid-primitives/keyed": "^1.5.0",
+    "@solid-primitives/map": "^0.6.0",
     "@solid-primitives/range": "^0.2.0",
     "clsx": "^2.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@solid-primitives/keyed':
         specifier: ^1.5.0
         version: 1.5.0(solid-js@1.8.17)
+      '@solid-primitives/map':
+        specifier: ^0.6.0
+        version: 0.6.0(solid-js@1.8.17)
       '@solid-primitives/range':
         specifier: ^0.2.0
         version: 0.2.0(solid-js@1.8.17)
@@ -820,6 +823,11 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@solid-primitives/map@0.6.0':
+    resolution: {integrity: sha512-h8uCJNxUTvzNK/aTW9vJCd/PQeBkUL8i7AyLPvTFqMgcMnJ1I5GzAi5JODzxpxQwffxoqJyQtOE1vBqFzDv0Vw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
   '@solid-primitives/memo@1.4.1':
     resolution: {integrity: sha512-MzNCJNpXidQdLOZUsEkwpuq52uwT8zrFrBxEVMEr9N35yIIvGhjqwrI1M6xzPmJGzuVUe8anCk57q+N5gyRk0Q==}
     peerDependencies:
@@ -832,6 +840,11 @@ packages:
 
   '@solid-primitives/scheduled@1.5.0':
     resolution: {integrity: sha512-RVw24IRNh1FQ4DCMb3OahB70tXIwc5vH8nhR4nNPsXwUPQeuOkLsDI5BlxaPk0vyZgqw9lDpufgI3HnPwplgDw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/trigger@1.2.0':
+    resolution: {integrity: sha512-sW4/3cDXSjYQampn8CIFZ11BlxgNf2li8r2fXnb3b3YWE6RdZZCl8PhvpPF38Gzl0CnryrbTPJWM7OIkseCDgQ==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -3006,6 +3019,11 @@ snapshots:
     dependencies:
       solid-js: 1.8.17
 
+  '@solid-primitives/map@0.6.0(solid-js@1.8.17)':
+    dependencies:
+      '@solid-primitives/trigger': 1.2.0(solid-js@1.8.17)
+      solid-js: 1.8.17
+
   '@solid-primitives/memo@1.4.1(solid-js@1.8.17)':
     dependencies:
       '@solid-primitives/scheduled': 1.5.0(solid-js@1.8.17)
@@ -3019,6 +3037,11 @@ snapshots:
 
   '@solid-primitives/scheduled@1.5.0(solid-js@1.8.17)':
     dependencies:
+      solid-js: 1.8.17
+
+  '@solid-primitives/trigger@1.2.0(solid-js@1.8.17)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.0(solid-js@1.8.17)
       solid-js: 1.8.17
 
   '@solid-primitives/utils@6.3.0(solid-js@1.8.17)':

--- a/src/create-file-system.ts
+++ b/src/create-file-system.ts
@@ -137,7 +137,7 @@ export function createFileSystem<T = string>() {
       setDirEnts(
         produce(files => {
           Object.keys(dirEnts).forEach(path => {
-            if (path.startsWith(previous)) {
+            if (PathUtils.isAncestor(path, previous) || path === previous) {
               const newPath = path.replace(previous, next)
               const file = files[path]!
               files[newPath] = file

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -86,11 +86,11 @@ export function useFileTree() {
   return context
 }
 
-const DirEntContext = createContext<DirEnt>()
+const DirEntContext = createContext<{ dirEnt: Accessor<DirEnt>, }>()
 export function useDirEnt() {
   const context = useContext(DirEntContext)
   if (!context) throw `DirEntContext is undefined`
-  return context
+  return context.dirEnt()
 }
 
 const DirEntIdContext = createContext<{ id: number, }>()
@@ -569,12 +569,12 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       }}
     >
       <FileTreeContext.Provider value={fileTreeContext}>
-        <Key each={flatTree()} by={item => item.dirEnt.path}>
+        <Key each={flatTree()} by={item => item.id}>
           {dirEnt => {
             return (
               <DirEntIdContext.Provider value={{ id: dirEnt().id, }}>
-                <DirEntContext.Provider value={dirEnt().dirEnt}>
-                  {untrack(() => props.children(dirEnt().dirEnt, fileTreeContext))}
+                <DirEntContext.Provider value={{ dirEnt: () => dirEnt().dirEnt}}>
+                  {props.children(dirEnt().dirEnt, fileTreeContext)}
                 </DirEntContext.Provider>
               </DirEntIdContext.Provider>
             )

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -119,6 +119,15 @@ function createIdGenerator() {
   const idToPathMap = new Map<number, string>()
   let nextId = 0
 
+  function createIdNode(path: string) {
+    const node = {
+      id: allocId(),
+      refCount: 1,
+    }
+    nodeMap.set(path, node)
+    idToPathMap.set(node.id, path)
+    return node
+  }
   function allocId() {
     return freeIds.pop() ?? nextId++
   }
@@ -129,7 +138,7 @@ function createIdGenerator() {
     onCleanup(() => {
       queueMicrotask(() => {
         node.refCount--
-        if (node.refCount == 0) {
+        if (node.refCount === 0) {
           disposeId(node.id)
           nodeMap.delete(path)
           idToPathMap.delete(node.id)
@@ -141,7 +150,7 @@ function createIdGenerator() {
   return {
     beforeRename(oldPath: string, newPath: string) {
       const node = nodeMap.get(oldPath)
-      if (node == undefined) {
+      if (node === undefined) {
         return
       }
       nodeMap.delete(oldPath)
@@ -155,12 +164,7 @@ function createIdGenerator() {
         addCleanup(node, path)
         return node.id
       } else {
-        const node = {
-          id: allocId(),
-          refCount: 1,
-        }
-        nodeMap.set(path, node)
-        idToPathMap.set(node.id, path)
+        const node = createIdNode(path)
         addCleanup(node, path)
         return node.id
       }
@@ -171,7 +175,7 @@ function createIdGenerator() {
         return
       }
       const node = nodeMap.get(path)
-      if (node != undefined) {
+      if (node !== undefined) {
         node.refCount++
         addCleanup(node, path)
       }

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -457,7 +457,6 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       beforeRename(oldPath, newPath)
       props.fs.rename(oldPath, newPath)
       props.onRename?.(oldPath, newPath)
-      focusDirEntById(newPath)
     })
   }
 

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -755,7 +755,7 @@ FileTree.Name = function (props: {
   const fileTree = useFileTree()
 
   function rename(element: HTMLInputElement) {
-    const newPath = [...dirEnt().path.split('/').slice(0, -1), element.value].join('/')
+    const newPath = PathUtils.rename(dirEnt().path, element.value)
 
     if (newPath === dirEnt().path) {
       return

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -246,15 +246,15 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   const baseId = createMemo(() => obtainId(config.base))
 
   // Focused DirEnt
-  const [focusedDirEnt, setFocusedDirEnt] = createSignal<string | undefined>()
-  const isDirEntFocused = createSelector(focusedDirEnt)
+  const [focusedDirEntId, setFocusedDirEntId] = createSignal<string | undefined>()
+  const isDirEntFocusedById = createSelector(focusedDirEntId)
 
-  function focusDirEnt(path: string) {
-    setFocusedDirEnt(path)
+  function focusDirEntById(id: string) {
+    setFocusedDirEntId(id)
   }
-  function blurDirEnt(path: string) {
-    if (focusedDirEnt() === path) {
-      setFocusedDirEnt()
+  function blurDirEntById(id: string) {
+    if (focusedDirEntId() === id) {
+      setFocusedDirEntId()
     }
   }
 
@@ -392,13 +392,13 @@ export function FileTree<T>(props: FileTreeProps<T>) {
                   renameDirEnt(idToPath(dirEnt().id), newPath)
                 },
                 focus() {
-                  focusDirEnt(idToPath(dirEnt().id))
+                  focusDirEntById(dirEnt().id)
                 },
                 blur() {
-                  blurDirEnt(idToPath(dirEnt().id))
+                  blurDirEntById(dirEnt().id)
                 },
                 get focused() {
-                  return isDirEntFocused(idToPath(dirEnt().id))
+                  return isDirEntFocusedById(dirEnt().id)
                 },
                 // Dir-specific API
                 get expand() {
@@ -467,7 +467,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       beforeRename(oldPath, newPath)
       props.fs.rename(oldPath, newPath)
       props.onRename?.(oldPath, newPath)
-      focusDirEnt(newPath)
+      focusDirEntById(newPath)
     })
   }
 
@@ -544,9 +544,9 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     deselectDirEntById,
     shiftSelectDirEntById,
     getDirEntsOfDirId,
-    focusDirEnt,
-    blurDirEnt,
-    isDirEntFocused,
+    focusDirEnt: focusDirEntById,
+    blurDirEnt: blurDirEntById,
+    isDirEntFocused: isDirEntFocusedById,
     pathToId,
   }
 
@@ -601,6 +601,14 @@ FileTree.DirEnt = function (
   const dirEnt = useDirEnt()
 
   const handlers = {
+    ref(element: HTMLButtonElement) {
+      createEffect(() => {
+        if (dirEnt().focused) {
+          element.focus()
+        }
+      })
+      props.ref?.(element)
+    },
     onPointerDown(event: WrapEvent<PointerEvent, HTMLButtonElement>) {
       batch(() => {
         if (event.shiftKey) {
@@ -653,14 +661,6 @@ FileTree.DirEnt = function (
     onBlur(event: WrapEvent<FocusEvent, HTMLButtonElement>) {
       dirEnt().blur()
       props.onBlur?.(event)
-    },
-    ref(element: HTMLButtonElement) {
-      onMount(() => {
-        if (dirEnt().focused) {
-          element.focus()
-        }
-      })
-      props.ref?.(element)
     },
   }
 

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -158,16 +158,14 @@ function createIdGenerator() {
       idToPathMap.set(node.id, newPath)
     },
     obtainId(path: string): number {
-      const node = nodeMap.get(path)
+      let node = nodeMap.get(path)
       if (node) {
         node.refCount++
-        addCleanup(node, path)
-        return node.id
       } else {
-        const node = createIdNode(path)
-        addCleanup(node, path)
-        return node.id
+        node = createIdNode(path)
       }
+      addCleanup(node, path)
+      return node.id
     },
     freezeId(id: number) {
       const path = idToPathMap.get(id)

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -767,6 +767,7 @@ FileTree.Name = function (props: {
     }
 
     dirEnt().rename(newPath)
+    dirEnt().focus()
   }
 
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,9 @@ export const PathUtils = {
     }
     return path
   },
+  rename(path: string, name: string) {
+    return [...path.split('/').slice(0, -1), name].join('/')
+  },
 }
 
 export function lastItem<T>(arr: Array<T>): T | undefined {


### PR DESCRIPTION
@clinuxrulz oopsie. 

continuation of https://github.com/bigmistqke/solid-fs-components/pull/5

TODO

- [x] Change selection and focus state to use IDs instead of paths.
- [x] createCompute over selection and focus IDs and freeze their IDs
- [x]  Render keyed by IDs rather than paths.
- [x]  Fix beforeRename to handle renaming parent folder. (Internally simulate beforeRename for each affected file that currently has an ID attached.)