### PR TITLE
Fixed beforeRename()

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@solid-primitives/keyed": "^1.5.0",
+    "@solid-primitives/map": "^0.6.0",
     "@solid-primitives/range": "^0.2.0",
     "clsx": "^2.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@solid-primitives/keyed':
         specifier: ^1.5.0
         version: 1.5.0(solid-js@1.8.17)
+      '@solid-primitives/map':
+        specifier: ^0.6.0
+        version: 0.6.0(solid-js@1.8.17)
       '@solid-primitives/range':
         specifier: ^0.2.0
         version: 0.2.0(solid-js@1.8.17)
@@ -820,6 +823,11 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@solid-primitives/map@0.6.0':
+    resolution: {integrity: sha512-h8uCJNxUTvzNK/aTW9vJCd/PQeBkUL8i7AyLPvTFqMgcMnJ1I5GzAi5JODzxpxQwffxoqJyQtOE1vBqFzDv0Vw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
   '@solid-primitives/memo@1.4.1':
     resolution: {integrity: sha512-MzNCJNpXidQdLOZUsEkwpuq52uwT8zrFrBxEVMEr9N35yIIvGhjqwrI1M6xzPmJGzuVUe8anCk57q+N5gyRk0Q==}
     peerDependencies:
@@ -832,6 +840,11 @@ packages:
 
   '@solid-primitives/scheduled@1.5.0':
     resolution: {integrity: sha512-RVw24IRNh1FQ4DCMb3OahB70tXIwc5vH8nhR4nNPsXwUPQeuOkLsDI5BlxaPk0vyZgqw9lDpufgI3HnPwplgDw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/trigger@1.2.0':
+    resolution: {integrity: sha512-sW4/3cDXSjYQampn8CIFZ11BlxgNf2li8r2fXnb3b3YWE6RdZZCl8PhvpPF38Gzl0CnryrbTPJWM7OIkseCDgQ==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -3006,6 +3019,11 @@ snapshots:
     dependencies:
       solid-js: 1.8.17
 
+  '@solid-primitives/map@0.6.0(solid-js@1.8.17)':
+    dependencies:
+      '@solid-primitives/trigger': 1.2.0(solid-js@1.8.17)
+      solid-js: 1.8.17
+
   '@solid-primitives/memo@1.4.1(solid-js@1.8.17)':
     dependencies:
       '@solid-primitives/scheduled': 1.5.0(solid-js@1.8.17)
@@ -3019,6 +3037,11 @@ snapshots:
 
   '@solid-primitives/scheduled@1.5.0(solid-js@1.8.17)':
     dependencies:
+      solid-js: 1.8.17
+
+  '@solid-primitives/trigger@1.2.0(solid-js@1.8.17)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.0(solid-js@1.8.17)
       solid-js: 1.8.17
 
   '@solid-primitives/utils@6.3.0(solid-js@1.8.17)':


### PR DESCRIPTION
A pull request for your pull request.

This currently fixes the `beforeRename` function, so when a parent folder is renamed, the child directory entries maintain their IDs.

It also restores the use of `untrack` when calling the children renderer for a `FileTree`. (For consistency with patterns in solid.). That one is a little bit funny, because actual `DirEnt` reference itself can change while the ID is the same for our current use of the ID middleware. That is why `createContext` for the current `DirEnt` is slightly different to the original. (`Context<Accessor<DirEnt>>` instead of `Context<DirEnt>`)

However the exposed interface for `useDirEnt` is the same as before, it just unboxes the memo inside. Down the track we might be able to work around that better with a `Proxy` for `DirEnt` so we have a stable reference for a `DirEnt` for a given ID.