### PR TITLE
Selection fixes

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -1,8 +1,7 @@
 import { Split } from '@bigmistqke/solid-grid-split'
 import { createSignal, onMount, type Component } from 'solid-js'
-import { PathUtils } from 'src/utils'
 import { TmTextarea } from 'tm-textarea/solid'
-import { createFileSystem, DefaultIndentGuide, FileTree } from '../src'
+import { createFileSystem, DefaultIndentGuide, FileTree, PathUtils } from '../src'
 import styles from './App.module.css'
 
 const project = import.meta.glob('../**/*', { as: 'raw', eager: true })

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -66,7 +66,8 @@ const App: Component = () => {
           onRename={(oldPath, newPath) =>
             setSelectedFile(file => PathUtils.rebase(file, oldPath, newPath))
           }
-          onSelection={console.log}
+          onSelectedPaths={console.log}
+          selectedPaths={['test/index.test.tsx']}
         >
           {dirEnt => {
             const [editable, setEditable] = createSignal(false)

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -66,6 +66,7 @@ const App: Component = () => {
           onRename={(oldPath, newPath) =>
             setSelectedFile(file => PathUtils.rebase(file, oldPath, newPath))
           }
+          onSelection={console.log}
         >
           {dirEnt => {
             const [editable, setEditable] = createSignal(false)

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -544,12 +544,17 @@ export function FileTree<T>(props: FileTreeProps<T>) {
 
   // Update selection from props
   createComputed(() => {
-    batch(() => {
-      if (!props.selection) return
-      setSelectedDirEntRanges(
-        props.selection.filter(id => props.fs.exists(idToPath(id))).map(id => [id] as [string]),
-      )
-    })
+    if (!props.selection) return
+    setSelectedDirEntRanges(
+      props.selection
+        .filter(path => props.fs.exists(path))
+        .map(
+          path =>
+            // NOTE:  this will keep the nodes longer in createIdGenerator's nodeMap
+            //        then strictly needed.
+            [obtainId(path)] as [string],
+        ),
+    )
   })
 
   // Freeze ID numbers for selected entries

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -149,12 +149,19 @@ function createIdGenerator() {
     onCleanup(() => {
       node.refCount--
       if (node.refCount <= 0) {
-        const path = idToPathMap.get(node.id)
-        disposeId(node.id)
-        idToPathMap.delete(node.id)
-        if (path) {
-          pathToNodeMap.delete(path)
-        }
+        // queue microtask just in case there is only one listener
+        queueMicrotask(() => {
+          // check if refCount got incremented before reaching the microtask
+          if (node.refCount > 0) {
+            return
+          }
+          const path = idToPathMap.get(node.id)
+          disposeId(node.id)
+          idToPathMap.delete(node.id)
+          if (path) {
+            pathToNodeMap.delete(path)
+          }
+        })
       }
     })
   }

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -540,7 +540,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   }
 
   // Call event handler with current selection
-  createEffect(() => props.onSelection?.(selectedDirEntIds()))
+  createEffect(() => props.onSelection?.(selectedDirEntIds().map(idToPath)))
 
   // Update selection from props
   createComputed(() => {

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -285,25 +285,15 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   }
 
   // Selected DirEnts
-  const [selectedDirEntRanges, setSelectedDirEntRanges] = createSignal<
-    Array<[start: string, end?: string]>
-  >([], { equals: false })
-
-  const selectedDirEntIds = createMemo(() => {
-    return selectedDirEntRanges()
-      .flatMap(([start, end]) => {
-        if (end) {
-          const startIndex = flatTree().findIndex(dir => dir.id === start)
-          const endIndex = flatTree().findIndex(dir => dir.id === end)
-
-          return flatTree()
-            .slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1)
-            .map(dirEnt => dirEnt.id)
-        }
-        return start
-      })
-      .sort((a, b) => (a < b ? -1 : 1))
+  const [selectedDirEntSpans, setSelectedDirEntSpans] = createSignal<Array<Array<string>>>([], {
+    equals: false,
   })
+
+  const selectedDirEntIds = createMemo(() =>
+    selectedDirEntSpans()
+      .flat()
+      .sort((a, b) => (a < b ? -1 : 1)),
+  )
 
   const isDirEntSelectedById = createSelector(selectedDirEntIds, (id: string, dirs) =>
     dirs.includes(id),
@@ -311,27 +301,46 @@ export function FileTree<T>(props: FileTreeProps<T>) {
 
   // Selection-methods
   function selectDirEntById(id: string) {
-    setSelectedDirEntRanges(dirEnts => [...dirEnts, [id]])
+    setSelectedDirEntSpans(dirEnts => [...dirEnts, [id]])
   }
+
   function deselectDirEntById(id: string) {
-    setSelectedDirEntRanges(
-      pairs =>
-        pairs
-          .map(dirEnts => dirEnts.filter(dirEnt => dirEnt !== id))
-          .filter(pair => pair.length > 0) as [string, string?][],
-    )
+    setSelectedDirEntSpans(pairs => pairs.map(dirEnts => dirEnts.filter(dirEnt => dirEnt !== id)))
   }
+
   function shiftSelectDirEntById(id: string) {
-    setSelectedDirEntRanges(dirEnts => {
-      if (dirEnts.length > 0) {
-        dirEnts[dirEnts.length - 1] = [dirEnts[dirEnts.length - 1]![0], id]
-        return [...dirEnts]
+    setSelectedDirEntSpans(ranges => {
+      // If the selection-ranges are empty, initialize it
+      if (ranges.length === 0) {
+        return [[id]]
       }
-      return [[id]]
+
+      const lastRange = ranges[ranges.length - 1]!
+
+      // If the last range is empty, initialize last range
+      if (lastRange.length === 0) {
+        ranges[ranges.length - 1] = [id]
+        return ranges
+      }
+
+      const startId = ranges[ranges.length - 1]![0]!
+      const startIndex = flatTree().findIndex(dir => dir.id === startId)
+      const endIndex = flatTree().findIndex(dir => dir.id === id)
+
+      ranges[ranges.length - 1] = flatTree()
+        .slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1)
+        .map(dirEnt => dirEnt.id)
+
+      if (startIndex > endIndex) {
+        ranges[ranges.length - 1]?.reverse()
+      }
+
+      return ranges
     })
   }
+
   function resetSelectedDirEntIds() {
-    setSelectedDirEntRanges([])
+    setSelectedDirEntSpans([])
   }
 
   // Expand/Collapse Dirs
@@ -571,7 +580,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   // Update selection from props
   createComputed(() => {
     if (!props.selectedPaths) return
-    setSelectedDirEntRanges(
+    setSelectedDirEntSpans(
       props.selectedPaths
         .filter(path => props.fs.exists(path))
         .map(path => [pathToId(path, false)] as [string]),

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -289,14 +289,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     equals: false,
   })
 
-  const selectedDirEntIds = createMemo(
-    () =>
-      new Set(
-        selectedDirEntSpans()
-          .flat()
-          .sort((a, b) => (a < b ? -1 : 1)),
-      ),
-  )
+  const selectedDirEntIds = createMemo(() => new Set(selectedDirEntSpans().flat()))
 
   const isDirEntSelectedById = createSelector(selectedDirEntIds, (id: string, dirs) => dirs.has(id))
 

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -147,12 +147,12 @@ function createIdGenerator() {
   }
   function addCleanup(node: IdNode) {
     onCleanup(() => {
+      const path = idToPathMap.get(node.id)
       queueMicrotask(() => {
         node.refCount--
         if (node.refCount <= 0) {
           disposeId(node.id)
           idToPathMap.delete(node.id)
-          const path = idToPathMap.get(node.id)
           if (path) {
             pathToNodeMap.delete(path)
           }

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -118,7 +118,7 @@ type IdNode = {
 // ID Generation Middleware
 function createIdGenerator() {
   const freeIds: Array<string> = []
-  const nodeMap = new ReactiveMap<string, IdNode>()
+  const nodeMap = new Map<string, IdNode>()
   const idToPathMap = new ReactiveMap<string, string>()
   let nextId = 0
 

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -289,15 +289,16 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     equals: false,
   })
 
-  const selectedDirEntIds = createMemo(() =>
-    selectedDirEntSpans()
-      .flat()
-      .sort((a, b) => (a < b ? -1 : 1)),
+  const selectedDirEntIds = createMemo(
+    () =>
+      new Set(
+        selectedDirEntSpans()
+          .flat()
+          .sort((a, b) => (a < b ? -1 : 1)),
+      ),
   )
 
-  const isDirEntSelectedById = createSelector(selectedDirEntIds, (id: string, dirs) =>
-    dirs.includes(id),
-  )
+  const isDirEntSelectedById = createSelector(selectedDirEntIds, (id: string, dirs) => dirs.has(id))
 
   // Selection-methods
   function selectDirEntById(id: string) {
@@ -498,7 +499,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   function moveSelectedDirEntsToPath(targetPath: string) {
     const targetId = pathToId(targetPath)
     const ids = selectedDirEntIds()
-    const paths = ids.map(idToPath)
+    const paths = Array.from(ids).map(idToPath)
     const existingPaths = new Array<{ newPath: string; oldPath: string }>()
 
     // Validate if any of the selected paths are ancestor of the target path
@@ -575,7 +576,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   }
 
   // Call event handler with current selection
-  createEffect(() => props.onSelectedPaths?.(selectedDirEntIds().map(idToPath)))
+  createEffect(() => props.onSelectedPaths?.(Array.from(selectedDirEntIds()).map(idToPath)))
 
   // Update selection from props
   createComputed(() => {

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -145,14 +145,17 @@ function createIdGenerator() {
   function disposeId(id: string) {
     freeIds.push(id)
   }
-  function addCleanup(node: IdNode, path: string) {
+  function addCleanup(node: IdNode) {
     onCleanup(() => {
       queueMicrotask(() => {
         node.refCount--
         if (node.refCount <= 0) {
           disposeId(node.id)
-          pathToNodeMap.delete(path)
           idToPathMap.delete(node.id)
+          const path = idToPathMap.get(node.id)
+          if (path) {
+            pathToNodeMap.delete(path)
+          }
         }
       })
     })
@@ -187,7 +190,7 @@ function createIdGenerator() {
       } else {
         node = createIdNode(path)
       }
-      addCleanup(node, path)
+      addCleanup(node)
       return node.id
     },
     /**
@@ -202,7 +205,7 @@ function createIdGenerator() {
       const node = pathToNodeMap.get(path)
       if (node !== undefined) {
         node.refCount++
-        addCleanup(node, path)
+        addCleanup(node)
       }
     },
     /** Reactively converts an ID back to a path */

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -147,17 +147,15 @@ function createIdGenerator() {
   }
   function addCleanup(node: IdNode) {
     onCleanup(() => {
-      const path = idToPathMap.get(node.id)
-      queueMicrotask(() => {
-        node.refCount--
-        if (node.refCount <= 0) {
-          disposeId(node.id)
-          idToPathMap.delete(node.id)
-          if (path) {
-            pathToNodeMap.delete(path)
-          }
+      node.refCount--
+      if (node.refCount <= 0) {
+        const path = idToPathMap.get(node.id)
+        disposeId(node.id)
+        idToPathMap.delete(node.id)
+        if (path) {
+          pathToNodeMap.delete(path)
         }
-      })
+      }
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './create-file-system'
 export * from './file-tree'
 export * from './file-tree/defaults'
+export * from './utils'


### PR DESCRIPTION
- fix onSelection (we were returning ids instead of the paths)
- fix props.selection (we were expecting ids to be passed)
- add second argument to `pathToId(path, assert)`
    - if `true/undefined`: will throw if id is undefined
    - if false: will create an idNode with reference count 0
- cleanup + documentation in createIdGenerator
- remove path from addCleanup (thanks @clinuxrulz)
- bikeshedding: renamed `freezeId` to `retainId`

TODO:
- [x] fix `selectedDirEntIds`-bug:
    - imagine the following setup:
        - 0.ts
        - 2.ts
    - if we select `0.ts` and then shift-select `2.ts` and then drag it into a folder that contains `1.ts` like
        - 0.ts
        - 1.ts
        - 2.ts
    - `1.ts` will currently also be selected
    - solution: to replace `selectedDirEntRanges` with another mechanism: 
        - instead of `Array<[number, number]>` it should be `Array<Array<string>>`