### PR TITLE
Cleanup expandedDirIds/selectedDirEntIds/focusedDirEntId when dirEnt does not exist

### DIFF
--- a/src/create-file-system.ts
+++ b/src/create-file-system.ts
@@ -160,7 +160,7 @@ export function createFileSystem<T = string>() {
           return value.includes(path)
         })
 
-        if (_dirEnts.length > 0) {
+        if (_dirEnts.length > 0 && !options?.force) {
           throw `Directory is not empty ${_dirEnts}`
         }
       }

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -273,6 +273,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
 
   // Focused DirEnt
   const [focusedDirEntId, setFocusedDirEntId] = createSignal<string | undefined>()
+
   const isDirEntFocusedById = createSelector(focusedDirEntId)
 
   function focusDirEntById(id: string) {
@@ -283,6 +284,14 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       setFocusedDirEntId()
     }
   }
+
+  // Cleanup of removed dirEnt from focusedDirEntId
+  createEffect(() => {
+    const _focusedDirEntId = focusedDirEntId()
+    if (_focusedDirEntId && !props.fs.exists(idToPath(_focusedDirEntId))) {
+      setFocusedDirEntId()
+    }
+  })
 
   // Selected DirEnts
   const [selectedDirEntSpans, setSelectedDirEntSpans] = createSignal<Array<Array<string>>>([], {

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -528,7 +528,11 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       })
 
     if (existingPaths.length > 0) {
-      throw new Error(`Paths already exist: ${existingPaths.map(({ newPath }) => newPath)}`)
+      throw new Error(
+        `Error while moving dirEnts. The following paths already exist:\n${existingPaths
+          .map(({ newPath }) => newPath)
+          .join('\n')}`,
+      )
     }
 
     // Apply transforms

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -84,14 +84,14 @@ interface FileTreeContext<T> {
 const FileTreeContext = createContext<FileTreeContext<any>>()
 export function useFileTree() {
   const context = useContext(FileTreeContext)
-  if (!context) throw `FileTreeContext is undefined`
+  if (!context) throw new Error(`FileTreeContext is undefined`)
   return context
 }
 
 const DirEntContext = createContext<Accessor<DirEnt>>()
 export function useDirEnt() {
   const context = useContext(DirEntContext)
-  if (!context) throw `DirEntContext is undefined`
+  if (!context) throw new Error(`DirEntContext is undefined`)
   return context
 }
 
@@ -100,7 +100,7 @@ type IndentGuideKind = 'pipe' | 'tee' | 'elbow' | 'spacer'
 const IndentGuideContext = createContext<Accessor<IndentGuideKind>>()
 export function useIndentGuide() {
   const context = useContext(IndentGuideContext)
-  if (!context) throw `IndentGuideContext is undefined`
+  if (!context) throw new Error(`IndentGuideContext is undefined`)
   return context
 }
 
@@ -498,10 +498,10 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     // Validate if any of the selected paths are ancestor of the target path
     for (const path of paths) {
       if (path === targetPath) {
-        throw `Cannot move ${path} into itself.`
+        throw new Error(`Cannot move ${path} into itself.`)
       }
       if (PathUtils.isAncestor(targetPath, path)) {
-        throw `Cannot move because ${path} is ancestor of ${targetPath}.`
+        throw new Error(`Cannot move because ${path} is ancestor of ${targetPath}.`)
       }
     }
 
@@ -528,7 +528,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       })
 
     if (existingPaths.length > 0) {
-      throw `Paths already exist: ${existingPaths.map(({ newPath }) => newPath)}`
+      throw new Error(`Paths already exist: ${existingPaths.map(({ newPath }) => newPath)}`)
     }
 
     // Apply transforms
@@ -794,7 +794,7 @@ FileTree.Name = function (props: {
 
     if (fileTree.fs.exists(newPath)) {
       element.value = dirEnt().name
-      throw `Path ${newPath} already exists.`
+      throw new Error(`Path ${newPath} already exists.`)
     }
 
     dirEnt().rename(newPath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './create-file-system'
 export * from './file-tree'
 export * from './file-tree/defaults'
-export * from './utils'
+export { PathUtils } from './utils'


### PR DESCRIPTION
before
- we had a cleanup function for expandedDirIds inside the keyArray-callback of the expandedDirs for when !fs.exists(dirEnt.path)
- this caused a bug where it would not cleanup the dirEnt if its parent was collapsed, causing an uncaught exception which broke the FileTree's functionality
- for selectedDirEntIds we never cleaned up when the !fs.exists(dirEnt.path), this did not cause an uncaught exception, but it did cause them to stay present in onSelectedPaths

after
- added cleanup-effects for expandedDirIds/expandedDirIds

misc
- wrap thrown messages in Error
- only export PathUtils from utils
- fix filesystem's rm(..., { force: true })