### PR TITLE
update selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,151 @@
 
 [![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-cc00ff.svg?style=for-the-badge&logo=pnpm)](https://pnpm.io/)
 
-Headless components for visualizing and interacting with reactive filesystem
+Headless components for visualizing and interacting with a reactive filesystem.
 
-**Currently implementing**
+**solid-fs-components** provides headless components for file explorers and folder trees in [SolidJS](https://www.solidjs.com/). You bring the UI — it handles the logic.
 
-- FileTree
+## Installation
 
-**Planning to implement**
+```bash
+pnpm add @bigmistqke/solid-fs-components
+```
 
-- (sortable) FileList
-- FileGrid
+## Components
+
+- [x] [FileTree](#filetree)
+- [ ] FileList (yet to implement)
+- [ ] FileGrid (yet to implement)
+
+## FileTree
+
+The `<FileTree>` component is a headless UI component designed to manage and render a reactive view of filesystem directories and files. This component handles the state and logic for expanding, collapsing, selecting, and moving files and directories.
+
+### Features
+
+- 📁 Expand and collapse directories
+- 🖱️ Multi-selection with ctrl-click/cmd-click
+- 🖱️ Range selection with shift-click
+- ⌨️ Keyboard navigation including space to toggle folders
+- 🚀 Drag-and-drop to reorganize entries
+- ✏️ Inline renaming
+- 🌍 ~~Compatible with any reactive filesystem model~~ (currently only sync filesystems supported)
+
+### Usage
+
+```tsx
+<FileTree
+  base="/"
+  fs={yourFileSystem}
+  onRename={(oldPath, newPath) => console.log(`Renamed \${oldPath} → \${newPath}`)}
+>
+  {(dirEnt, fileTree) => (
+    <FileTree.DirEnt>
+      <FileTree.IndentGuides render={kind => <span class="indent" data-kind={kind()} />} />
+      <FileTree.Expanded collapsed={<span>▶</span>} expanded={<span>▼</span>} />
+      <FileTree.Name editable />
+    </FileTree.DirEnt>
+  )}
+</FileTree>
+```
+
+### Props
+
+- `base`: Root path to begin rendering from (default is `"/"`).
+- `fs`: An implementation of the FileSystem interface:
+  - `readdir(path)`: Retrieves directories and files.
+  - `rename(oldPath, newPath)`: Moves or renames files or directories.
+  - `exists(path)`: Checks if a path exists.
+
+### Compound Components
+
+#### FileTree.DirEnt
+
+This subcomponent wraps individual directory or file entries, handling all user interactions such as selection, focus, drag-and-drop, and expand/collapse operations.
+
+#### FileTree.IndentGuides
+
+Renders visual guides indicating the nesting level of each directory, customizable via a render prop.
+
+#### FileTree.Expanded
+
+Provides a toggle icon indicating whether a directory is expanded or collapsed.
+
+#### FileTree.Name
+
+Displays and optionally allows editing of the directory or file name.
+
+## FileSystem Interface
+
+To use `FileTree`, you need to implement the following FileSystem interface:
+
+```ts
+interface FileSystem {
+  readdir(path: string): Array<{ path: string; type: 'file' | 'dir' }>
+  rename(oldPath: string, newPath: string): void
+  exists(path: string): boolean
+}
+```
+
+### Context Hooks
+
+- **useFileTree()**: Access the file tree context for operations like expanding, collapsing, selecting, or moving entries.
+- **useDirEnt()**: Access the properties and methods related to the directory entry currently being rendered.
+- **useIndentGuide()** Access the indent guide kind
+
+### API
+
+#### useFileTree
+
+```ts
+{
+  getDirEntsOfDirId(path: string): Array<DirEnt>
+  expandDirById(id: string): void
+  collapseDirById(id: string): void
+  isDirExpandedById(id: string): boolean
+  resetSelectedDirEntIds(): void
+  moveToPath(path: string): void
+  selectDirEntById(id: string): void
+  shiftSelectDirEntById(id: string): void
+  deselectDirEntById(id: string): void
+  focusDirEnt(path: string): void
+  blurDirEnt(path: string): void
+  isDirEntFocused(path: string): boolean
+  pathToId(path: string): string
+}
+```
+
+#### useDirEnt
+
+```ts
+{
+  id: string,
+  path: string,
+  name: string,
+  type: "file" | "dir",
+  selected: boolean,
+  focused: boolean,
+  indentation: number,
+  select(): void,
+  deselect(): void,
+  shiftSelect(): void,
+  rename(path: string): void,
+  focus(): void,
+  blur(): void,
+  expand?(): void,
+  collapse?(): void,
+  expanded?: boolean
+}
+```
+
+### useIndentGuide()
+
+Used inside `<FileTree.IndentGuides>` to get the current guide kind:
+
+```ts
+const kind = useIndentGuide() // returns Accessor<"pipe" | "tee" | "elbow" | "spacer">
+```
+
+## License
+
+MIT © 2025

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -94,13 +94,7 @@ const App: Component = () => {
                       setEditable(editable => !editable)
                       break
                     case 'Space':
-                      if (_dirEnt.type === 'dir') {
-                        if (_dirEnt.expanded) {
-                          _dirEnt.collapse()
-                        } else {
-                          _dirEnt.expand()
-                        }
-                      } else {
+                      if (_dirEnt.type === 'file') {
                         setSelectedFile(_dirEnt.path)
                       }
                       break

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -65,8 +65,6 @@ const App: Component = () => {
           onRename={(oldPath, newPath) =>
             setSelectedFile(file => PathUtils.rebase(file, oldPath, newPath))
           }
-          onSelectedPaths={console.log}
-          selectedPaths={['test/index.test.tsx']}
         >
           {dirEnt => {
             const [editable, setEditable] = createSignal(false)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-fs-components",
-  "version": "0.0.0",
+  "version": "0.1.0-beta",
   "description": "headless components for visualizing and interacting with reactive filesystem",
   "license": "MIT",
   "author": "bigmistqke",

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -14,7 +14,6 @@ import {
   type JSX,
   mapArray,
   mergeProps,
-  on,
   onCleanup,
   onMount,
   Show,
@@ -616,17 +615,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
 
   // Update selection from props
   createComputed(
-    on(
-      () => props.selectedPaths,
-      selectedPaths => {
-        if (!selectedPaths) return
-        setSelectedDirEntSpans(
-          selectedPaths
-            .filter(path => props.fs.exists(path))
-            .map(path => [pathToId(path, false)] as [string]),
-        )
-      },
-    ),
+    () => props.selectedPaths?.map(path => pathToId(path, false)).forEach(selectDirEntById),
   )
 
   // Freeze ID numbers for selected entries

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -70,7 +70,7 @@ interface FileTreeContext<T> {
   isDirExpandedById(id: string): boolean
   // Selection
   resetSelectedDirEntIds(): void
-  moveSelectedDirEntsToPath(path: string): void
+  moveToPath(path: string): void
   selectDirEntById(id: string): void
   shiftSelectDirEntById(id: string): void
   deselectDirEntById(id: string): void
@@ -520,9 +520,17 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     })
   }
 
-  function moveSelectedDirEntsToPath(targetPath: string) {
+  function moveToPath(targetPath: string) {
+    const _focusedDirEntId = focusedDirEntId()
+
+    if (!_focusedDirEntId) {
+      throw new Error('Attempted to moveToPath without dirEnt focused')
+    }
+
     const targetId = pathToId(targetPath)
-    const ids = selectedDirEntIds()
+    const ids = selectedDirEntIds().includes(_focusedDirEntId)
+      ? selectedDirEntIds()
+      : [_focusedDirEntId]
     const paths = ids.map(idToPath)
     const existingPaths = new Array<{ newPath: string; oldPath: string }>()
 
@@ -588,19 +596,19 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     get base() {
       return config.base
     },
+    getDirEntsOfDirId,
+    moveToPath,
+    pathToId,
     expandDirById,
     collapseDirById,
     isDirExpandedById,
-    moveSelectedDirEntsToPath,
-    resetSelectedDirEntIds,
     selectDirEntById,
     deselectDirEntById,
     shiftSelectDirEntById,
-    getDirEntsOfDirId,
+    resetSelectedDirEntIds,
     focusDirEnt: focusDirEntById,
     blurDirEnt: blurDirEntById,
     isDirEntFocused: isDirEntFocusedById,
-    pathToId,
   }
 
   // Call event handler with current selection
@@ -634,7 +642,7 @@ export function FileTree<T>(props: FileTreeProps<T>) {
         props.onDragOver?.(event)
       }}
       onDrop={event => {
-        moveSelectedDirEntsToPath(config.base)
+        moveToPath(config.base)
         props.onDrop?.(event)
       }}
     >
@@ -722,9 +730,9 @@ FileTree.DirEnt = function (
       const _dirEnt = dirEnt()
 
       if (_dirEnt.type === 'dir') {
-        fileTree.moveSelectedDirEntsToPath(_dirEnt.path)
+        fileTree.moveToPath(_dirEnt.path)
       } else {
-        fileTree.moveSelectedDirEntsToPath(PathUtils.getParent(_dirEnt.path))
+        fileTree.moveToPath(PathUtils.getParent(_dirEnt.path))
       }
 
       props.onDrop?.(event)

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -255,6 +255,7 @@ export type FileTreeProps<T> = Overwrite<
     base?: string
     children: (dirEnt: Accessor<DirEnt>, fileTree: FileTreeContext<T>) => JSX.Element
     fs: Pick<FileSystem<T>, 'readdir' | 'rename' | 'exists'>
+    onPointerUp?(event: WrapEvent<PointerEvent, HTMLDivElement>): void
     onDragOver?(event: WrapEvent<DragEvent, HTMLDivElement>): void
     onDrop?(event: WrapEvent<DragEvent, HTMLDivElement>): void
     onRename?(oldPath: string, newPath: string): void
@@ -633,6 +634,12 @@ export function FileTree<T>(props: FileTreeProps<T>) {
       onDrop={event => {
         moveToPath(config.base)
         props.onDrop?.(event)
+      }}
+      onPointerUp={event => {
+        if (event.currentTarget === event.target) {
+          resetSelectedDirEntIds()
+        }
+        props.onPointerUp?.(event)
       }}
     >
       <FileTreeContext.Provider value={fileTreeContext}>

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -650,6 +650,7 @@ FileTree.DirEnt = function (
     ComponentProps<'button'>,
     {
       ref?(element: HTMLButtonElement): void
+      onKeyDown?(event: WrapEvent<KeyboardEvent, HTMLButtonElement>): void
       onDragOver?(event: WrapEvent<DragEvent, HTMLButtonElement>): void
       onDragStart?(event: WrapEvent<DragEvent, HTMLButtonElement>): void
       onDrop?(event: WrapEvent<DragEvent, HTMLButtonElement>): void
@@ -672,6 +673,24 @@ FileTree.DirEnt = function (
         }
       })
       props.ref?.(element)
+    },
+    onKeyDown(event: WrapEvent<KeyboardEvent, HTMLButtonElement>) {
+      const _dirEnt = dirEnt()
+      switch (event.code) {
+        case 'Space':
+          if (_dirEnt.type === 'dir') {
+            if (_dirEnt.expanded) {
+              _dirEnt.collapse()
+            } else {
+              _dirEnt.expand()
+            }
+          } else {
+            fileTree.resetSelectedDirEntIds()
+            _dirEnt.select()
+          }
+          break
+      }
+      props.onKeyDown?.(event)
     },
     onPointerUp(event: WrapEvent<PointerEvent, HTMLButtonElement>) {
       const _dirEnt = dirEnt()

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -14,6 +14,7 @@ import {
   type JSX,
   mapArray,
   mergeProps,
+  on,
   onCleanup,
   onMount,
   Show,
@@ -606,14 +607,19 @@ export function FileTree<T>(props: FileTreeProps<T>) {
   createEffect(() => props.onSelectedPaths?.(selectedDirEntIds().map(idToPath)))
 
   // Update selection from props
-  createComputed(() => {
-    if (!props.selectedPaths) return
-    setSelectedDirEntSpans(
-      props.selectedPaths
-        .filter(path => props.fs.exists(path))
-        .map(path => [pathToId(path, false)] as [string]),
-    )
-  })
+  createComputed(
+    on(
+      () => props.selectedPaths,
+      selectedPaths => {
+        if (!selectedPaths) return
+        setSelectedDirEntSpans(
+          selectedPaths
+            .filter(path => props.fs.exists(path))
+            .map(path => [pathToId(path, false)] as [string]),
+        )
+      },
+    ),
+  )
 
   // Freeze ID numbers for selected entries
   createComputed(() => selectedDirEntIds().forEach(freezeId))

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -660,7 +660,6 @@ FileTree.DirEnt = function (
       onDragStart?(event: WrapEvent<DragEvent, HTMLButtonElement>): void
       onDrop?(event: WrapEvent<DragEvent, HTMLButtonElement>): void
       onMove?(parent: string): void
-      onPointerDown?(event: WrapEvent<PointerEvent, HTMLButtonElement>): void
       onPointerUp?(event: WrapEvent<PointerEvent, HTMLButtonElement>): void
       onFocus?(event: WrapEvent<FocusEvent, HTMLButtonElement>): void
       onBlur?(event: WrapEvent<FocusEvent, HTMLButtonElement>): void
@@ -680,32 +679,37 @@ FileTree.DirEnt = function (
       })
       props.ref?.(element)
     },
-    onPointerDown(event: WrapEvent<PointerEvent, HTMLButtonElement>) {
+    onPointerUp(event: WrapEvent<PointerEvent, HTMLButtonElement>) {
+      const _dirEnt = dirEnt()
+
       batch(() => {
+        // Handle dirEnt-selection
         if (event.shiftKey) {
           dirEnt().shiftSelect()
         } else {
-          if (!dirEnt().selected) {
-            if (!event[CTRL_KEY]) {
-              fileTree.resetSelectedDirEntIds()
+          if (event[CTRL_KEY]) {
+            // Toggle selection when ctrl is pressed
+            if (!dirEnt().selected) {
+              dirEnt().select()
+            } else {
+              dirEnt().deselect()
             }
+          } else {
+            // Reset selection to this dirEnt
+            fileTree.resetSelectedDirEntIds()
             dirEnt().select()
-          } else if (event[CTRL_KEY]) {
-            dirEnt().deselect()
+          }
+        }
+        // Handle dir-expand/collapse
+        if (_dirEnt.type === 'dir') {
+          if (_dirEnt.expanded) {
+            _dirEnt.collapse()
+          } else {
+            _dirEnt.expand()
           }
         }
       })
-      props.onPointerDown?.(event)
-    },
-    onPointerUp(event: WrapEvent<PointerEvent, HTMLButtonElement>) {
-      const _dirEnt = dirEnt()
-      if (_dirEnt.type === 'dir') {
-        if (_dirEnt.expanded) {
-          _dirEnt.collapse()
-        } else {
-          _dirEnt.expand()
-        }
-      }
+
       props.onPointerUp?.(event)
     },
     onDragOver: (event: WrapEvent<DragEvent, HTMLButtonElement>) => {

--- a/src/file-tree/index.tsx
+++ b/src/file-tree/index.tsx
@@ -259,8 +259,6 @@ export type FileTreeProps<T> = Overwrite<
     onDragOver?(event: WrapEvent<DragEvent, HTMLDivElement>): void
     onDrop?(event: WrapEvent<DragEvent, HTMLDivElement>): void
     onRename?(oldPath: string, newPath: string): void
-    onSelectedPaths?(paths: string[]): void
-    selectedPaths?: Array<string>
     sort?(dirEnt1: DirEnt, dirEnt2: DirEnt): number
   }
 >
@@ -610,14 +608,6 @@ export function FileTree<T>(props: FileTreeProps<T>) {
     blurDirEnt: blurDirEntById,
     isDirEntFocused: isDirEntFocusedById,
   }
-
-  // Call event handler with current selection
-  createEffect(() => props.onSelectedPaths?.(selectedDirEntIds().map(idToPath)))
-
-  // Update selection from props
-  createComputed(
-    () => props.selectedPaths?.map(path => pathToId(path, false)).forEach(selectDirEntById),
-  )
 
   // Freeze ID numbers for selected entries
   createComputed(() => selectedDirEntIds().forEach(freezeId))


### PR DESCRIPTION
- [x] fix bug with effect selecting props.selectedPaths
    - without explicit dependencies it would also update whenever fs.exists(path) would change.
    - this would cause a bug in the following situation:
        1. selectedPaths={[dir/file.ts]}
        2. dir is selected
        3. dir is dragged into dir2:  dir2/dir
        4. because dir/file.ts would cease to exist it would call the effect selecting props.selectedPaths
        5. causing dir2/dir to stop being selected
    - to see this bug in action in the current demo: drag `test` into another dir.
    - we could also to remove this functionality all together and keep the selectedPaths as an internal state
- [x] when selecting a dirEnt (without dragging) it should reset the selection to this dirEnt
    - this is accomplished by updating the selection onPointerUp instead of onPointerDown
- [x] selecting the FileTree itself resets the selection